### PR TITLE
【ユーザー機能】マイページで回答が表示されていない事象の改修およびデザイン修正 issues/#77

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,13 +1,13 @@
 module ApplicationHelper
   def profile_img(user)
-    return image_tag(user.avatar, alt: user.name) if user.avatar?
+    return image_tag(user.avatar, alt: user.name, size: "200x200") if user.avatar?
 
     unless user.provider.blank?
       img_url = user.image_url
     else
       img_url = 'no_image.png'
     end
-    image_tag(img_url, alt: user.name)
+    image_tag(img_url, alt: user.name, size: "200x200")
   end
 
   def switch_active_class(c_name, a_name='')

--- a/app/views/answers/_index.html.erb
+++ b/app/views/answers/_index.html.erb
@@ -11,7 +11,7 @@
             <% end %>
             <div class="text-right">
               <p>answered <%= answer.created_at.strftime("%Y年 %m月 %d日, %H:%M:%S") %></p>
-              <p><%= answer.user.name %></p>
+              <p><%= link_to answer.user.name, user_path(answer.user) %></p>
             </div>
             <div id="contribute_area" class="text-left">
             <% if user_signed_in? %>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -20,7 +20,8 @@
 
   <div class="text-right">
     <p>asked <%= @question.created_at.strftime("%Y年 %m月 %d日, %H:%M:%S") %></p>
-    <p><%= @question.user.name %></p>
+    <p><%= link_to @question.user.name, user_path(@question.user) %></p>
+
   </div>
 
 <div id="contribute_area" class="text-left">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,7 +2,6 @@
   <h2><%= @user.name %>さんの詳細</h2>
   <%= profile_img(@user) %>
   <p><%= @user.name %></p>
-  <p><%= @user.profile %></p>
   <p><%= @user.email %></p>
 
   <p>貢献度</p>
@@ -10,15 +9,14 @@
   <% if current_user && @user.id === current_user.id %>
       <p><%= link_to '編集する', edit_user_registration_path %></p>
   <% end %>
-
-  <h3><%= @user.name %>さんの質問</h3>
+  <h3>投稿した質問</h3>
   <ul class="myPage-list">
     <% unless @questions.empty? %>
         <% @questions.each do |question| %>
             <li>
-              <h4 class="text-left"><%= question.q_points.length %>
-                票 <%= link_to question.title, question_path(question.id) %></h4>
-              <p class="text-right"><%= question.created_at.strftime("%Y年 %m月 %d日, %H:%M:%S") %></p>
+              <h5 class="text-left"><%= link_to question.title, question_path(question.id) %></h4>
+              <p class="text-left"><%= "#{question.q_points.length}票" %></p>
+              <p class ="text-right"><%= question.created_at.strftime("%Y年 %m月 %d日, %H:%M:%S") %></p>
             </li>
         <% end %>
     <% else %>
@@ -26,13 +24,13 @@
     <% end %>
   </ul>
 
-  <h3><%= @user.name %>さんの回答</h3>
+  <h3>投稿した回答</h3>
   <ul class="myPage-list">
     <% unless @answers.empty? %>
         <% @answers.each do |answer| %>
             <li>
-              <h4 class="text-left"><%= link_to answer.question.title, question_path(answer.question.id, anchor: answer.id) %></h4>
-              <p class="text-left">answer.content</p>
+              <h5 class="text-left"><%= link_to answer.content.truncate(200), question_path(answer.question.id, anchor: answer.id) %></h4>
+              <p class="text-left"><%= "#{answer.a_points.length}票" %></p>
               <p class="text-right"><%= answer.created_at.strftime("%Y年 %m月 %d日, %H:%M:%S") %></p>
             </li>
         <% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -44,23 +44,21 @@ fileT.close
   t_array = tagsArray.to_a.shuffle[0...tag_num]
   q.tag_list = t_array.join(',')
   q.save
+
+  # Answer(1つのQuestionあたり最大5件の回答)
+  ans_num = Faker::Number.between(0, 5)
+  ans_num.times do |n|
+    contentA = Faker::Lorem.paragraphs.join
+    user_id = Faker::Number.between(1, User.count)
+    Answer.create!(
+      content: contentA,
+      user_id: user_id,
+      question_id: q.id
+    )
+  end
 end
 
 fileQ.close
-
-
-# Answer
-100.times do |n|
-  content = Faker::Lorem.paragraphs.join
-  user_id = Faker::Number.between(1, User.count)
-  question_id = Faker::Number.between(1, Question.count)
-  Answer.create!(
-      content: content,
-      user_id: user_id,
-      question_id: question_id
-  )
-end
-
 
 # Favorite(1人のUserあたり最大15件のお気に入り)
 (User.count).times do |n|


### PR DESCRIPTION
- 質問詳細画面におけるユーザー名にマイページへのリンクを付加
- マイページの画像サイズを変更(未指定→200X200)
- マイページに回答が表示されていない不具合の改修
- マイページで表示する回答は200文字で切り詰め
- 回答のシードデータ見直し(100件固定→1つの質問あたり最大5件に変更)







